### PR TITLE
#99 adding codecov support for the repo

### DIFF
--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -55,3 +55,8 @@ jobs:
           nosetests
         env:
           DATABASE_URI: "postgresql://postgres:postgres@postgres:5432/postgres"
+      
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v2
+        with:
+          version: "v0.1.13" 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,8 @@ cover-package=service
 exe=1
 # with-xunit=1
 # xunit-file=./unittests.xml
-# cover-xml=1
-# cover-xml-file=./coverage.xml
+cover-xml=1
+cover-xml-file=./coverage.xml
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Has the changes to add codecov support for the repo.

I still need to add the codecov badge on he `README.md`. I will add it once this gets merged and if there are no issues.