### PR TITLE
Bugfix/nosetests pipeline - modify active query string

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -244,10 +244,6 @@ class TestCustomersServer(TestCase):
             BASE_URL, query_string="active=False")
         not_active_found = not_active_found.get_json()
 
-        logging.info(active_found)
-        logging.info(not_active_found)
-        logging.info(Customer.all())
-
         self.assertEqual(len(active_found), 2)
         self.assertEqual(len(not_active_found), 1)
 


### PR DESCRIPTION
Modified the query string in `test_get_customer_by_active` so that active is always casted as boolean and does not fail in the CD Pipeline.
Added and removed logging statements after testing.