### PR TITLE
Setting ERROR_404_HELP to false in app config

### DIFF
--- a/service/__init__.py
+++ b/service/__init__.py
@@ -14,6 +14,7 @@ from service.common import log_handlers
 app = Flask(__name__)
 app.url_map.strict_slashes = False
 app.config.from_object(config)
+app.config['ERROR_404_HELP'] = False
 
 ######################################################################
 # Configure Swagger before initializing it


### PR DESCRIPTION
Extraneous response message when retrieving non-existent customers fixed. 