### PR TITLE
Added check for customer_id in read, delete and updated flash msg

### DIFF
--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -342,6 +342,12 @@ $(function () {
 
         let customer_id = $("#customer_id").val();
 
+        if(!customer_id){
+            displayFieldRequiredNotification("#customer_id")
+            $("#flash_message").html("Form Error(s)")
+            return false
+        };
+
         $("#flash_message").empty();
 
         let ajax = $.ajax({
@@ -371,6 +377,12 @@ $(function () {
 
         let customer_id = $("#customer_id").val();
 
+        if(!customer_id){
+            displayFieldRequiredNotification("#customer_id")
+            $("#flash_message").html("Form Error(s)")
+            return false
+        };
+
         $("#flash_message").empty();
 
         let ajax = $.ajax({
@@ -386,7 +398,7 @@ $(function () {
         });
 
         ajax.fail(function(res){
-            flash_message("Server error!")
+            flash_message(res.responseJSON.message)
         });
     });
 


### PR DESCRIPTION
- The flash message for error in Delete is updated to reflect the correct error. 
- Null checking for customer_id when Retrieve or Delete is called in the UI is added.